### PR TITLE
Update docs for Tailwind setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ A modern, responsive Astro template with Tailwind CSS and Alpine.js integration.
 │       ├── global.css
 │       └── transitions.css
 ├── astro.config.mjs    # Astro configuration
-├── tailwind.config.mjs # Tailwind CSS configuration
 └── package.json        # Project dependencies
 ```
 
@@ -62,14 +61,15 @@ All commands are run from the root of the project, from a terminal:
 
 ### Colors
 
-The template includes a custom color palette defined in `tailwind.config.mjs`:
+The template defines its color palette using CSS custom properties in
+`src/styles/global.css`:
 
 - Primary: Purple-based color scheme
 - Secondary: Slate-based color scheme
 - Accent: Lime-based color scheme
 - Warning: Yellow-based color scheme
 
-You can customize these colors by editing the `tailwind.config.mjs` file.
+Adjust these variables in `global.css` to change the look and feel.
 
 ### Typography
 


### PR DESCRIPTION
## Summary
- remove outdated references to `tailwind.config.mjs`
- point users to `src/styles/global.css` for color variables

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: `astro` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848fc895ca4832d881a0f6b10415932