### PR TITLE
Make header sticky

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -67,7 +67,7 @@ const mainMenu = [
   // },
 ];
 ---
-<header class="w-full bg-white/90 dark:bg-secondary-950/90 backdrop-blur-xs z-50 py-4 transition-colors duration-300">
+<header class="sticky top-0 w-full bg-white/90 dark:bg-secondary-950/90 backdrop-blur-xs z-50 py-4 transition-colors duration-300">
   <div class="container-custom flex items-center justify-between">
     <a href="/" class="flex items-center" aria-label="Ir a la página principal">
       <DistrictLogo class="w-48 sm:w-64 md:w-96 mr-12" />


### PR DESCRIPTION
## Summary
- make header sticky so it remains visible when scrolling

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_684904674c64832da75eabd232c79e9a