### PR TITLE
Add ProgramHero component and update program layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,34 @@ Custom animations are included:
 3. Start the development server with `npm run dev` or `pnpm dev`
 4. Visit `http://localhost:4321` to see your site
 
+## ➕ Adding New Programs
+
+Program pages live in `src/pages/programas`. When creating a new program file, provide the hero information through the `hero` property that is passed to `ProgramLayout`:
+
+```astro
+<ProgramLayout
+  title={programInfo.title}
+  age={programInfo.age}
+  duration={programInfo.duration}
+  programCode={programInfo.programCode}
+  logo={programInfo.logo}
+  hero={programInfo.hero}
+>
+```
+
+The `hero` object should include:
+
+```ts
+hero: {
+  title: string;            // Main heading
+  highlightText?: string;   // Word to highlight in the title
+  description: string;      // Short description displayed under the title
+  image?: ImageMetadata;    // Optional background image
+}
+```
+
+This information is rendered by the `ProgramHero` component at the top of each program page.
+
 ## 📝 License
 
 MIT

--- a/src/components/ProgramHero.astro
+++ b/src/components/ProgramHero.astro
@@ -1,0 +1,43 @@
+---
+import type { ImageMetadata } from 'astro';
+interface Props {
+  title: string;
+  highlightText?: string;
+  description: string;
+  image?: ImageMetadata;
+}
+const { title, highlightText, description, image } = Astro.props;
+let titleStart = title;
+let titleEnd = "";
+if (highlightText) {
+  const parts = title.split(highlightText);
+  if (parts.length > 1) {
+    titleStart = parts[0];
+    titleEnd = parts[1];
+  }
+}
+---
+<section class="relative overflow-hidden bg-linear-to-b from-primary-100 to-white dark:from-primary-950 dark:to-secondary-950 pt-24 md:pt-32 pb-16 md:pb-20">
+  {image && (
+    <img src={image.src} alt={image.alt || ''} class="absolute inset-0 w-full h-full object-cover opacity-30" />
+  )}
+  <div class="absolute inset-0 z-0 opacity-30">
+    <div class="absolute inset-0 bg-grid-pattern"></div>
+  </div>
+  <div class="container-custom relative z-10">
+    <div class="text-center max-w-3xl mx-auto px-4">
+      <h1 class="text-3xl md:text-4xl lg:text-5xl mb-4 md:mb-6 text-gray-900 dark:text-white animate-slide-down">
+        {highlightText ? (
+          <>
+            {titleStart}<span class="dark:text-accent-500 text-secondary-500">{highlightText}</span>{titleEnd}
+          </>
+        ) : (
+          title
+        )}
+      </h1>
+      <p class="text-lg md:text-xl text-gray-700 dark:text-gray-300 mb-6 md:mb-8 animate-slide-up" style="animation-delay: 200ms">
+        {description}
+      </p>
+    </div>
+  </div>
+</section>

--- a/src/layouts/ProgramLayout.astro
+++ b/src/layouts/ProgramLayout.astro
@@ -1,5 +1,13 @@
 ---
 import Layout from './Layout.astro';
+import ProgramHero from '../components/ProgramHero.astro';
+
+interface HeroProps {
+  title: string;
+  highlightText?: string;
+  description: string;
+  image?: ImageMetadata;
+}
 
 interface Props {
   title: string;
@@ -7,10 +15,11 @@ interface Props {
   duration: string;
   programCode: string;
   logo: ImageMetadata;
+  hero: HeroProps;
   applicationFormLink?: string;
 }
 
-const { title, age, duration, programCode, logo, applicationFormLink } = Astro.props;
+const { title, age, duration, programCode, logo, hero, applicationFormLink } = Astro.props;
 
 const metadata = {
   title: `${programCode} (${title} de ${duration})`,
@@ -22,36 +31,7 @@ const formUrl = applicationFormLink ?? `/programas/${programCode}/aplicar`;
 
 <Layout metadata={metadata}>
   <!-- 1. Hero del programa -->
-  <section class="py-20">
-    <div class="container-custom">
-      <div class="grid md:grid-cols-2 gap-12 items-center">
-        <div class="flex flex-col gap-6">
-          <h1 class="text-4xl md:text-5xl font-bold text-gray-900 dark:text-white mb-4">{title}</h1>
-          <div class="flex flex-wrap gap-4 my-6 text-gray-600 dark:text-white">
-            <span class="badge bg-primary-100 dark:bg-secondary-500 px-3">
-              Edad: {age} años
-            </span>
-            <span class="badge bg-primary-100 dark:bg-secondary-500 px-3">
-              Duración: {duration}
-            </span>
-            <span class="badge bg-primary-100 dark:bg-secondary-500 px-3">
-              [{programCode}]
-            </span>
-          </div>
-          <a href="#aplicar" class="btn btn-primary mt-6 w-fit">Quiero participar</a>
-        </div>
-        <div class="flex justify-center">
-          <div class="w-64 h-64 overflow-hidden">
-            <img
-                src={logo.src}
-                alt={`Logo de ${title}`}
-                class="w-full h-full object-contain p-4"
-              />
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
+  <ProgramHero {...hero} />
 
   <!-- Contenido principal -->
   <slot />

--- a/src/pages/programas/ngse.astro
+++ b/src/pages/programas/ngse.astro
@@ -26,6 +26,13 @@ const programInfo = {
   programCode: "NGSE",
   logo: logoNgse,
 
+  hero: {
+    title: "Programa NGSE",
+    highlightText: "NGSE",
+    description: "El Programa de Intercambio de Nuevas Generaciones para Servicio (NGSE) está diseñado para adultos jóvenes que desean adquirir experiencia profesional o realizar voluntariado en el extranjero.",
+    image: ngseTestimonial1,
+  },
+
   description: "El Programa de Intercambio de Nuevas Generaciones para Servicio (NGSE) está diseñado para adultos jóvenes que desean adquirir experiencia profesional o realizar voluntariado en el extranjero. Este programa combina la inmersión cultural con el desarrollo profesional, permitiendo a los participantes aplicar sus habilidades y conocimientos en entornos internacionales mientras viven con familias anfitrionas o en alojamientos coordinados por Rotary.",
 
   benefits: [
@@ -186,6 +193,7 @@ const programInfo = {
   duration={programInfo.duration}
   programCode={programInfo.programCode}
   logo={programInfo.logo}
+  hero={programInfo.hero}
 >
   <ProgramContent
     description={programInfo.description}

--- a/src/pages/programas/rye-camps.astro
+++ b/src/pages/programas/rye-camps.astro
@@ -25,6 +25,13 @@ const programInfo = {
   programCode: "RYE-CAMPS",
   logo: ryeLogo,
 
+  hero: {
+    title: "Campamentos Internacionales",
+    highlightText: "Campamentos",
+    description: "Los Campamentos Internacionales de Rotary ofrecen experiencias temáticas intensivas y cortas donde jóvenes de múltiples países se reúnen para actividades específicas.",
+    image: ryeCampsTestimonial1,
+  },
+
   description: "Los Campamentos Internacionales de Rotary ofrecen experiencias temáticas intensivas y cortas donde jóvenes de múltiples países se reúnen para actividades específicas. Estos campamentos pueden centrarse en deportes, arte, música, desarrollo de liderazgo, aventura al aire libre, o temas culturales, brindando una inmersión internacional sin el compromiso de tiempo de otros programas.",
 
   benefits: [
@@ -189,6 +196,7 @@ const programInfo = {
   duration={programInfo.duration}
   programCode={programInfo.programCode}
   logo={programInfo.logo}
+  hero={programInfo.hero}
 >
   <ProgramContent
     description={programInfo.description}

--- a/src/pages/programas/rye-ltep.astro
+++ b/src/pages/programas/rye-ltep.astro
@@ -2,6 +2,7 @@
 import ProgramLayout from '../../layouts/ProgramLayout.astro';
 import ProgramContent from '../../components/ProgramContent.astro';
 import logoRye from '../../assets/images/logo-rye.png';
+import ltepImage from '../../assets/images/testimonials/ltep-2023-brazil-sohannys.jpg';
 import { ProgramCode } from '../../const';
 import { getLatestTestimonialsForProgram } from '../../utils/collections/testimonials';
 
@@ -24,6 +25,13 @@ const programInfo = {
   duration: "10-12 meses",
   programCode: "RYE-LTEP",
   logo: logoRye,
+
+  hero: {
+    title: "Año Escolar",
+    highlightText: "Escolar",
+    description: "El Programa de Intercambio de Jóvenes a Largo Plazo (LTEP) es la experiencia más completa de Rotary para estudiantes de secundaria.",
+    image: ltepImage,
+  },
 
   description: "El Programa de Intercambio de Jóvenes a Largo Plazo (LTEP) es la experiencia más completa de Rotary para estudiantes de secundaria. Durante un año académico completo, los participantes viven con familias anfitrionas en otro país mientras asisten a una escuela local, aprenden un nuevo idioma y se sumergen completamente en una cultura diferente.",
 
@@ -242,6 +250,7 @@ const programInfo = {
   duration={programInfo.duration}
   programCode={programInfo.programCode}
   logo={programInfo.logo}
+  hero={programInfo.hero}
 >
   <ProgramContent
     description={programInfo.description}

--- a/src/pages/programas/rye-step.astro
+++ b/src/pages/programas/rye-step.astro
@@ -23,6 +23,12 @@ const programInfo = {
   programCode: "RYE-STEP",
   logo: logoRye,
 
+  hero: {
+    title: "Intercambio de Vacaciones",
+    highlightText: "Vacaciones",
+    description: "El Programa de Intercambio de Vacaciones (STEP) ofrece a los jóvenes una experiencia internacional más breve pero igualmente enriquecedora.",
+  },
+
   description: "El Programa de Intercambio de Vacaciones (STEP) ofrece a los jóvenes una experiencia internacional más breve pero igualmente enriquecedora. Este intercambio de familia a familia permite a los participantes pasar de 1 a 3 meses en otro país durante sus vacaciones escolares, viviendo con una familia anfitriona cuyo hijo visitará luego su hogar en reciprocidad.",
 
   benefits: [
@@ -161,6 +167,7 @@ const programInfo = {
   duration={programInfo.duration}
   programCode={programInfo.programCode}
   logo={programInfo.logo}
+  hero={programInfo.hero}
 >
   <ProgramContent
     description={programInfo.description}


### PR DESCRIPTION
## Summary
- create `ProgramHero` component for new program hero section
- use `<ProgramHero>` inside `ProgramLayout`
- provide hero data for NGSE, RYE LTEP, RYE STEP and RYE camps pages
- document how to add hero content for new programs in README

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856a5b05704832d9d0b50d97f479b9c