### PR TITLE
Make Layout.astro language configurable

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -11,9 +11,13 @@ import Footer from '../components/Footer.astro';
 
 export interface Props {
   metadata?: MetaData;
+  /**
+   * Document language. Defaults to Spanish.
+   */
+  lang?: string;
 }
 
-const { metadata } = Astro.props;
+const { metadata, lang = 'es' } = Astro.props;
 
 const rawTitle = metadata?.title || "Intercambios Juveniles";
 
@@ -25,7 +29,7 @@ const metadataWithDefaults = {
 ---
 
 <!doctype html>
-<html lang="en" x-data="{ darkMode: localStorage.getItem('darkMode') === 'true' }" x-init="$watch('darkMode', val => localStorage.setItem('darkMode', val))" :class="{ 'dark': darkMode }">
+<html lang={lang} x-data="{ darkMode: localStorage.getItem('darkMode') === 'true' }" x-init="$watch('darkMode', val => localStorage.setItem('darkMode', val))" :class="{ 'dark': darkMode }">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
## Summary
- allow `Layout` to accept a `lang` prop
- default the document language to Spanish

## Testing
- `npm run build` *(fails: `astro` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68568e0c520c832dbe57159a3637567f